### PR TITLE
Fix typo in en and fr licences

### DIFF
--- a/license/license_g1-en.rst
+++ b/license/license_g1-en.rst
@@ -56,7 +56,7 @@ Each member has a stock of 100 possible certifications, which can only be issued
 
 Valid for 2 months, certification for a new member is definitively adopted only if the certified has at least 4 other certifications after these 2 months, otherwise the entry process will have to be relaunched.
 
-To become a new member of WoT Ğ1 therefore 5 certifications must be obtained at a distance> 5 of 80% of the WoT sentinels.
+To become a new member of WoT Ğ1 therefore 5 certifications must be obtained at a distance < 5 of 80% of the WoT sentinels.
 
 A member of the TdC Ğ1 is sentinel when he has received and issued at least Y [N] certifications where N is the number of members of the TdC and Y [N] = ceiling N ^ (1/5). Examples:
 

--- a/license/license_g1-en.rst
+++ b/license/license_g1-en.rst
@@ -1,8 +1,8 @@
-License Ğ1 - v0.2.3
+License Ğ1 - v0.2.5
 ===================
 
 :date: 2017-08-21 16:59
-:modified: 2017-08-21 16:59
+:modified: 2018-01-24 19:20
 
 **Money licensing and liability commitment.**
 

--- a/license/license_g1-fr-FR.rst
+++ b/license/license_g1-fr-FR.rst
@@ -1,8 +1,8 @@
-Licence Ğ1 - v0.2.4
+Licence Ğ1 - v0.2.5
 ===================
 
 :date: 2017-04-04 12:59
-:modified: 2017-10-14 10:23
+:modified: 2018-01-24 19:20
 
 **Licence de la monnaie et engagement de responsabilité.**
 

--- a/license/license_g1-fr-FR.rst
+++ b/license/license_g1-fr-FR.rst
@@ -45,7 +45,7 @@ Chaque membre a un stock de 100 certifications possibles, qu'il ne peut émettre
 
 Valable 2 mois, une certification pour un nouveau membre n'est définitivement adoptée que si le certifié possède au moins 4 autres certifications au bout de ces 2 mois, sinon le processus d'entrée devra être relancé.
 
-Pour devenir un nouveau membre de la TdC Ğ1 il faut donc obtenir 5 certifications et ne pas se trouver à une distance > 5 de 80% des membres référents de la TdC.
+Pour devenir un nouveau membre de la TdC Ğ1 il faut donc obtenir 5 certifications et ne pas se trouver à une distance < 5 de 80% des membres référents de la TdC.
 
 Un membre de la TdC Ğ1 est membre référent lorsqu'il a reçu et émis au moins Y[N] certifications où N est le nombre de membres de la TdC et Y[N] = plafond N^(1/5). Exemples :
 


### PR DESCRIPTION
The distance should be inferior to 5, and not superior to 5.